### PR TITLE
Fix missing npm start script and allow configurable port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # nofstack
 Nodejs over Fortran.
-Use `npm run watch` in development and `npm start` to boot the server.
+
+## Usage
+
+```bash
+npm install
+npm run watch   # development build/watch
+PORT=18080 npm start  # boot the server (default port is 8080)
+```
 
 ### TODO
 *Write something useful here.*

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js",
     "watch": "gulp build && gulp watch"
   },
   "author": "",

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const config = require('./package.json').nofstack;
 
 const main = './' + config.mainOut;
 
-const port = 8080;
+const port = process.env.PORT || 8080;
 
 function handleRequest(request, response){
   exec(main + ' ' + request.url, (error, stdout, stderr) => {


### PR DESCRIPTION
## Summary
- add a missing `start` script so the documented `npm start` command actually works
- make server port configurable via `PORT` env var (still defaults to `8080`)
- refresh README usage section with explicit install/start commands

## Validation
- `PORT=18080 npm start`
  - observed: `Server listening on: http://localhost:18080`
