### PR TITLE
ci: add syntax smoke test for server and gulpfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Nodejs over Fortran.
 
 ```bash
 npm install
+npm test        # quick syntax smoke test for server/build scripts
 npm run watch   # development build/watch
 PORT=18080 npm start  # boot the server (default port is 8080)
 ```

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Fortran backed blogging engine",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "npm run test:syntax",
     "start": "node server.js",
-    "watch": "gulp build && gulp watch"
+    "watch": "gulp build && gulp watch",
+    "test:syntax": "node --check server.js && node --check gulpfile.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- replace the placeholder failing `npm test` script with a deterministic syntax smoke check
- add `test:syntax` to validate `server.js` and `gulpfile.js` with `node --check`
- document `npm test` in README usage

## Why
The repository currently has a hard-failing placeholder test (`exit 1`), which makes local verification and CI unusable. This change introduces a low-risk, quick feedback check without altering runtime behavior.

## Validation
- `npm test`

Output: passes (`node --check server.js && node --check gulpfile.js`)
